### PR TITLE
metadata: Tidy up

### DIFF
--- a/net.blockbench.Blockbench.metainfo.xml
+++ b/net.blockbench.Blockbench.metainfo.xml
@@ -6,7 +6,9 @@
     <summary>Blockbench - A boxy 3D model editor</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
-    <developer_name>JannisX11</developer_name>
+    <developer id="net.blockbench>
+        <name>JannisX11</name>
+    </developer>
     <categories>
         <category>Graphics</category>
         <category>3DGraphics</category>
@@ -42,60 +44,6 @@
         <release version="5.0.4" date="2025-11-10"/>
         <release version="5.0.3" date="2025-10-25"/>
         <release version="5.0.2" date="2025-10-16"/>
-        <release version="4.12.6" date="2025-08-05"/>
-        <release version="4.12.5" date="2025-06-17"/>
-        <release version="4.12.1" date="2025-01-16"/>
-        <release version="4.11.2" date="2024-11-02"/>
-        <release version="4.11.1" date="2024-09-28"/>
-        <release version="4.11.0" date="2024-09-22"/>
-        <release version="4.10.3" date="2024-06-05"/>
-        <release version="4.10.2" date="2024-05-29"/>
-        <release version="4.10.1" date="2024-05-13"/>
-        <release version="4.10.0" date="2024-05-09"/>
-        <release version="4.9.4" date="2024-02-16"/>
-        <release version="4.9.3" date="2024-01-03"/>
-        <release version="4.9.2" date="2023-12-16"/>
-        <release version="4.9.1" date="2023-12-04"/>
-        <release version="4.9.0" date="2023-12-02"/>
-        <release version="4.8.3" date="2023-08-30"/>
-        <release version="4.8.2" date="2023-08-27"/>
-        <release version="4.8.1" date="2023-07-30"/>
-        <release version="4.8.0" date="2023-07-27"/>
-        <release version="4.7.4" date="2023-05-27"/>
-        <release version="4.7.3" date="2023-05-27"/>
-        <release version="4.7.2" date="2023-04-30"/>
-        <release version="4.7.1" date="2023-04-24"/>
-        <release version="4.7.0" date="2023-04-17"/>
-        <release version="4.6.5" date="2023-03-09"/>
-        <release version="4.6.4" date="2023-02-04"/>
-        <release version="4.6.3" date="2023-02-02"/>
-        <release version="4.6.2" date="2023-02-01"/>
-        <release version="4.6.1" date="2023-01-20"/>
-        <release version="4.6.0" date="2023-01-16"/>
-        <release version="4.5.2" date="2022-11-20"/>
-        <release version="4.5.1" date="2022-11-12"/>
-        <release version="4.5.0" date="2022-11-10"/>
-        <release version="4.4.3" date="2022-10-19"/>
-        <release version="4.4.2" date="2022-10-02"/>
-        <release version="4.4.1" date="2022-09-16"/>
-        <release version="4.4.0" date="2022-09-15"/>
-        <release version="4.3.1" date="2022-07-25"/>
-        <release version="4.3.0" date="2022-07-22"/>
-        <release version="4.2.5" date="2022-06-10"/>
-        <release version="4.2.4" date="2022-04-29"/>
-        <release version="4.2.3" date="2022-04-23"/>
-        <release version="4.2.2" date="2022-04-03"/>
-        <release version="4.2.1" date="2022-03-30"/>
-        <release version="4.2.0" date="2022-03-29"/>
-        <release version="4.1.5" date="2022-02-12"/>
-        <release version="4.1.4" date="2022-02-01"/>
-        <release version="4.1.2" date="2022-01-14"/>
-        <release version="4.1.1" date="2021-12-23"/>
-        <release version="4.1.0" date="2021-12-21"/>
-        <release version="4.0.5" date="2021-11-17"/>
-        <release version="4.0.4" date="2021-11-09"/>
-        <release version="4.0.3" date="2021-10-27"/>
-        <release version="4.0.1" date="2021-10-15"/>
     </releases>
     <content_rating type="oars-1.1"/>
 </component>

--- a/net.blockbench.Blockbench.metainfo.xml
+++ b/net.blockbench.Blockbench.metainfo.xml
@@ -6,7 +6,7 @@
     <summary>Blockbench - A boxy 3D model editor</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
-    <developer id="net.blockbench>
+    <developer id="net.blockbench">
         <name>JannisX11</name>
     </developer>
     <categories>


### PR DESCRIPTION
### Use the developer block, instad of developer_name tag

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#developer-name

### Drop redundant release information 

GNOME Software and Bazaar only show the last few entries. They already have no real information. There is no harm in dropping them.