### PR TITLE
use x11, and not fallback-x11

### DIFF
--- a/net.blockbench.Blockbench.yaml
+++ b/net.blockbench.Blockbench.yaml
@@ -12,8 +12,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=wayland
-  - --socket=fallback-x11
-
+  - --socket=x11
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download

--- a/net.blockbench.Blockbench.yaml
+++ b/net.blockbench.Blockbench.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=wayland
   - --socket=x11
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents


### PR DESCRIPTION
As I stated in #76. I made this change in my fork, and have tested it on my system (Fedora 43 KDE), and in a virtual machine that's running Debian with KDE (X11), and this works fine on both, and it appears Jannis has also made this change on their machine as well, and it's worked.

From my research, the version of Electron upstream uses (38.1) defaults to X11 still anyway, and this was only changed in 38.2 from what I can find