### PR TITLE
Blockbench binary changed from capital to lowercase again

### DIFF
--- a/net.blockbench.Blockbench.yaml
+++ b/net.blockbench.Blockbench.yaml
@@ -46,7 +46,7 @@ modules:
       - type: script
         dest-filename: blockbench-run
         commands:
-          - zypak-wrapper /app/bin/Blockbench/Blockbench "$@"
+          - zypak-wrapper /app/bin/Blockbench/blockbench "$@"
       - type: file
         path: net.blockbench.Blockbench.metainfo.xml
       - type: file


### PR DESCRIPTION
If you extract the app image, you will see that the binary is no longer called "Blockbench" it is instead now called just "blockbench", I really don't know why the capitalization change happened, but here's a pull request that resolves it and should make it so that this can be updated to 5.1.0